### PR TITLE
Add option to change the style of the set-auto merge button.

### DIFF
--- a/background.js
+++ b/background.js
@@ -8,6 +8,9 @@ chrome.storage.local.get(['hideBypass', 'showTitle', 'showTag'], function (resul
     if (result.showTag === undefined) {
         chrome.storage.local.set({showTag: true});
     }
+    if (result.autoMergeSecondary === undefined) {
+        chrome.storage.local.set({autoMergeSecondary: true});
+    }
 });
 
 
@@ -16,7 +19,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     console.log('received message', request);
 
     if (request.action === "settings") {
-        chrome.storage.local.get(['hideBypass','showTitle', 'showTag'], function (result) {
+        chrome.storage.local.get(['hideBypass','showTitle', 'showTag', 'autoMergeSecondary'], function (result) {
             sendResponse({ result });
         });
         return true; // Keeps the message channel open for async sendResponse

--- a/content.js
+++ b/content.js
@@ -112,6 +112,22 @@ window.addEventListener('load', () => {
     }
 
     function changeAutoMergeStyle() {
+        // Using a mutation observer to watch for changes in the document as Gitlab renders the MR buttons after the initial load
+        const observer = new MutationObserver((mutationsList, observer) => {
+            const autoMergeButton = document.querySelector('[data-testid="merge-button"]');
+
+            if (autoMergeButton) {
+                const internalSpan = autoMergeButton.querySelector('.gl-button-text')
+                if(internalSpan && internalSpan.innerText === 'Set to auto-merge'){
+                    console.debug('found auto-merge button', autoMergeButton, internalSpan);
+                    autoMergeButton.classList.remove('btn-confirm');
+                }
+                observer.disconnect();
+            }
+
+        });
+
+        observer.observe(document.body, { childList: true, subtree: true });
 
     }
 

--- a/content.js
+++ b/content.js
@@ -111,6 +111,10 @@ window.addEventListener('load', () => {
 
     }
 
+    function changeAutoMergeStyle() {
+
+    }
+
 
     (async () => {
         const response = await chrome.runtime.sendMessage({action: "settings"});
@@ -123,7 +127,8 @@ window.addEventListener('load', () => {
             settings = {
                 showTitle: true,
                 hideBypass: true,
-                showTag: true
+                showTag: true,
+                autoMergeSecondary: true,
             };
         } else {
             settings = response.result;
@@ -135,6 +140,11 @@ window.addEventListener('load', () => {
             if(settings.showTitle){
                 console.debug('adding copy title button');
                 addCopyButtonMR();
+            }
+
+            if(settings.autoMergeSecondary){
+                console.debug('Changing auto merge button to be in secondary style.');
+                changeAutoMergeStyle();
             }
 
             if(settings.hideBypass){

--- a/popup.html
+++ b/popup.html
@@ -40,7 +40,7 @@
         </label>
     </div>
     <div>
-        <label for="show-tag-copy">
+        <label for="change-automerge-button">
             <input type="checkbox" id="change-automerge-button">
             Change 'Set to auto-merge' button to secondary style.
         </label>

--- a/popup.html
+++ b/popup.html
@@ -39,6 +39,12 @@
             Show tag copy button
         </label>
     </div>
+    <div>
+        <label for="show-tag-copy">
+            <input type="checkbox" id="change-automerge-button">
+            Change 'Set to auto-merge' button to secondary style.
+        </label>
+    </div>
 </div>
 
 <script src="popup.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -2,9 +2,10 @@ document.addEventListener('DOMContentLoaded', function () {
     const bypassCheckbox = document.getElementById('hide-bypass');
     const showTitleCheckbox = document.getElementById('show-title-copy');
     const showTagCopy = document.getElementById('show-tag-copy');
+    const changeAutomergeButton = document.getElementById('change-automerge-button');
 
     // Load the saved states from local storage when popup opens
-    chrome.storage.local.get(['hideBypass', 'showTitle', 'showTag'], function (result) {
+    chrome.storage.local.get(['hideBypass', 'showTitle', 'showTag', 'autoMergeSecondary'], function (result) {
         console.debug('hide-bypass', result.hideBypass);
         bypassCheckbox.checked = result.hideBypass;
 
@@ -13,21 +14,29 @@ document.addEventListener('DOMContentLoaded', function () {
 
         console.debug('showTag', result.showTag);
         showTagCopy.checked = result.showTag;
+
+        console.debug('autoMergeSecondary', result.autoMergeSecondary);
+        changeAutomergeButton.checked = result.autoMergeSecondary;
     });
 
     // Save the checkbox states to local storage when toggled
     bypassCheckbox.addEventListener('change', function () {
-        console.debug('Hide bypass button changed', bypassCheckbox.checked);
+        console.debug('Hide bypass checkbox changed', bypassCheckbox.checked);
         chrome.storage.local.set({ hideBypass: bypassCheckbox.checked });
     });
 
     showTitleCheckbox.addEventListener('change', function () {
-        console.debug('Show Title button changed', showTitleCheckbox.checked);
+        console.debug('Show Title checkbox changed', showTitleCheckbox.checked);
         chrome.storage.local.set({ showTitle: showTitleCheckbox.checked });
     });
 
     showTagCopy.addEventListener('change', function () {
-        console.debug('Show Tag button changed', showTagCopy.checked);
+        console.debug('Show Tag checkbox changed', showTagCopy.checked);
         chrome.storage.local.set({ showTag: showTagCopy.checked });
+    });
+
+    changeAutomergeButton.addEventListener('change', function () {
+        console.debug('Change Automerge Button style checkbox changed', changeAutomergeButton.checked);
+        chrome.storage.local.set({ autoMergeSecondary: changeAutomergeButton.checked });
     });
 });


### PR DESCRIPTION
This PR will add an option to the extension to remove the 'primary button' style from the 'Set auto-merge' button.

Some developers have been confused by the primary style and pressed this button when they instead wanted to approve an MR.


- [x] Adds option to popup
- [x] Changes style to 'regular' or 'secondary' 
- [x] Only change style if it is labeled as 'set to auto-merge'




