### PR TITLE
feat: Clean up MR URLs to remove sub-paths and fragments

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,10 +1,15 @@
 console.log("Loaded Gitlab MR copy tool");
 
 window.addEventListener('load', () => {
+    function cleanMrUrl(url) {
+        const match = url.match(/^(.*\/-\/merge_requests\/\d+)/);
+        return match ? match[1] : url;
+    }
+
     function addCopyButtonMR() {
         const actionContainerElement = document.querySelector('.merge-request .detail-page-header');
         const mrTitleElement = document.querySelector('.merge-request .detail-page-header .title');
-        const mrUrl = window.location.href;
+        const mrUrl = cleanMrUrl(window.location.href);
 
         if(mrTitleElement){
             console.log("Title:", mrTitleElement.innerText);


### PR DESCRIPTION
## Summary

This PR adds URL cleanup functionality to ensure that copied MR URLs always point to the main MR page instead of sub-pages like pipelines, diffs, or commits.

## Changes

- Added `cleanMrUrl()` function to extract base MR URL using regex pattern
- Modified `addCopyButtonMR()` to use cleaned URLs instead of raw `window.location.href`
- Handles URLs with sub-paths (`/pipelines`, `/diffs`, `/commits`) and fragments (`#hash`)

## Example

**Before:**
- URL: `https://gitlab.example.com/group/project/-/merge_requests/4172/pipelines#14cc16209e782516ab64882860bbc0d2c7b00ea0`
- Copied: Same messy URL

**After:**
- URL: `https://gitlab.example.com/group/project/-/merge_requests/4172/pipelines#14cc16209e782516ab64882860bbc0d2c7b00ea0`
- Copied: `https://gitlab.example.com/group/project/-/merge_requests/4172`

This ensures users always get clean, shareable MR links that point directly to the main MR page.